### PR TITLE
feat: introduce npm-ci workflow

### DIFF
--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -1,0 +1,44 @@
+name: Reusable CI
+
+on:
+  workflow_call:
+    inputs:
+      skip-tests:
+        type: boolean
+        default: false
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: node-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        if: ${{ inputs.skip-tests == false }}
+        run: npm test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
This pull request introduces a reusable GitHub Actions workflow for continuous integration (CI). The workflow is designed to streamline build, linting, testing, and packaging processes for Node.js projects.

### CI Workflow Implementation:

* [`.github/workflows/npm-ci.yml`](diffhunk://#diff-0886856b99a59ca164f5a8c53d04d50498d730fa38cac7677868ecfec21bba34R1-R44): Added a reusable CI workflow named "Reusable CI" that supports optional skipping of tests via an input parameter. The workflow includes steps for checking out the repository, setting up Node.js, caching `node_modules`, installing dependencies, linting, running tests (conditionally), and building the project.

### Other information
* Basically, this workflow is copied from [asimov-protocol/.github](https://github.com/asimov-protocol/.github/blob/v1.0/.github/workflows/npm-ci.yml) and I thought it would be nice to have a separate workflow here
