### PR TITLE
feat: use new node version

### DIFF
--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Cache node_modules
         uses: actions/cache@v4


### PR DESCRIPTION
This pull request updates the Node.js version used in the GitHub Actions workflow for continuous integration.

* [`.github/workflows/npm-ci.yml`](diffhunk://#diff-0886856b99a59ca164f5a8c53d04d50498d730fa38cac7677868ecfec21bba34L21-R21): Updated the `node-version` in the `Use Node.js` step from `18` to `22` to ensure compatibility with the latest Node.js features and improvements.